### PR TITLE
#10 create two S3 buckets via terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# terraform
+.terraform*

--- a/terraform/backend.sh
+++ b/terraform/backend.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+
+SUFFIX=$(date +%s)
+aws s3api  create-bucket --bucket nc-terraform-state-${SUFFIX} --region us-east-1
+

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,7 +1,7 @@
 terraform {
     backend "s3" {
-        bucket = "nc-terraform-state-1679394142"
-        key = "s3_file_reader/terraform.tfstate"
+        bucket = "nc-terraform-state-1679397451"
+        key = "tote-application/terraform.tfstate"
         region = "us-east-1"
     }
 }

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,6 +1,6 @@
 terraform {
     backend "s3" {
-        bucket = "nc-terraform-state-1679394142q"
+        bucket = "nc-terraform-state-1679394142"
         key = "s3_file_reader/terraform.tfstate"
         region = "us-east-1"
     }

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+    backend "s3" {
+        bucket = "nc-terraform-state-1679394142q"
+        key = "s3_file_reader/terraform.tfstate"
+        region = "us-east-1"
+    }
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "code_bucket" {
+  bucket_prefix = var.code_bucket_prefix
+}
+

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -2,3 +2,7 @@ resource "aws_s3_bucket" "code_bucket" {
   bucket_prefix = var.code_bucket_prefix
 }
 
+resource "aws_s3_bucket" "ingestion_zone_bucket" {
+  bucket_prefix = var.ingestion_zone_bucket_prefix
+}
+

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -2,3 +2,8 @@ variable "code_bucket_prefix" {
     type = string
     default = "lambda-code-"
 }
+
+variable "ingestion_zone_bucket_prefix" {
+    type = string
+    default = "ingestion-zone-"
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,0 +1,4 @@
+variable "code_bucket_prefix" {
+    type = string
+    default = "lambda-code-"
+}


### PR DESCRIPTION
Initial configuration of terraform with a backend S3 bucket. 
Creates two buckets with prefixes lambda-code and ingestion-zone.
Gitignore has been updated to ignore terraform state files.
Tested on two sandboxes 
